### PR TITLE
Add property to main activity to keep screen on

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/frameLayout">
+    android:id="@+id/frameLayout"
+    android:keepScreenOn="true">
 
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"


### PR DESCRIPTION
This means that, when the app is open, the phone will not automatically
go to sleep. Battery life be damned!